### PR TITLE
Fixed in-memory cache not updated on toggle

### DIFF
--- a/api/enabled.lua
+++ b/api/enabled.lua
@@ -25,6 +25,7 @@ end
 function api.toggle_enabled(player_name)
 	local key = f("toggled:%s", player_name)
 	local toggled = is_yes(mod_storage:get(key))
+	cache[player_name] = not toggled
 	if toggled then
 		mod_storage:set_string(key, "")
 		return false


### PR DESCRIPTION
Without this, the `/toggle_choppy` command has no effect until a server restart due to memory caching of state.